### PR TITLE
Extend runtime config with overlay options

### DIFF
--- a/Assets/Plugins/BuildUtility/Editor/VersionPromptWindow.cs
+++ b/Assets/Plugins/BuildUtility/Editor/VersionPromptWindow.cs
@@ -84,10 +84,17 @@ namespace Opodlinok.BuildUtility.Editor
                 ChangelogManager.CopyChangelogToBuildFolder(
                     _settings.ChangelogPathFormat, buildDir);
 
-            var cfg = new { releaseBuild = _releaseBuild };
+            var config = new
+            {
+                releaseBuild = _releaseBuild,
+                enableOverlay = _settings.EnableOverlay,
+                overlayPosition = _settings.OverlayPosition.ToString(),
+                showStudioLabel = _settings.ShowStudioLabel
+            };
+
             File.WriteAllText(
                 Path.Combine(buildDir, "BuildUtilityConfig.json"),
-                JsonUtility.ToJson(cfg));
+                JsonUtility.ToJson(config));
 
             _defaultHandler?.Invoke(_opts);
         }


### PR DESCRIPTION
- In VersionPromptWindow.Execute(): 
• Write enableOverlay, overlayPosition, showStudioLabel into BuildUtilityConfig.json alongside releaseBuild.

Closes #14 